### PR TITLE
rescuing from exception raised when collecting exceptions with compare

### DIFF
--- a/lib/logjam_agent.rb
+++ b/lib/logjam_agent.rb
@@ -135,19 +135,7 @@ module LogjamAgent
 
   def self.determine_loaded_exception_classes
     ObjectSpace.each_object(Class) do |klass|
-      begin
-        auto_detect_exception(klass) if klass < Exception
-      rescue ArgumentError
-        # some klazzes do implement 'self.<=>(other)' used by Comparable
-        # returning nil, which is ok from the ruby specs but results in
-        # an error like:
-        #
-        #   ArgumentError: comparison of Class with Class failed
-        #
-        # when comparing it like 'klass < Exception'
-        # [ class A; extend ::Comparable; def self.<=>(o); nil; end; end ]
-        # occured with gem 'axiom'
-      end
+      auto_detect_exception(klass) if klass.ancestors.include?(Exception)
     end
     reset_exception_matcher
   end


### PR DESCRIPTION
Hey,

we currently have a problem with logjam agent when collecting the exceptions in object space (see comment below).

This is a first suggestions how to fix the problem. Maybe there's a better way to do 'klass < Exception'.

greets,
Jochen
