### PR TITLE
Make logjam agent work on heroku.

### DIFF
--- a/lib/logjam_agent/railtie.rb
+++ b/lib/logjam_agent/railtie.rb
@@ -49,7 +49,11 @@ module LogjamAgent
 
       # install a default error handler for forwarding errors
       log_dir = File.dirname(logjam_log_path(app))
-      forwarding_error_logger = ::Logger.new("#{log_dir}/logjam_agent_error.log")
+      begin
+        forwarding_error_logger = ::Logger.new("#{log_dir}/logjam_agent_error.log")
+      rescue StandardError
+        forwarding_error_logger = ::Logger.new(STDERR)
+      end
       forwarding_error_logger.level = ::Logger::ERROR
       forwarding_error_logger.formatter = ::Logger::Formatter.new
       LogjamAgent.forwarding_error_logger = forwarding_error_logger


### PR DESCRIPTION
Hi Stefan,

on Heroku your app is not allowed to write log files to the file system. Instead it should write its logs to STDERR. I've just copied the behaviour of Rails:

https://github.com/rails/rails/blob/08754f12e65a9ec79633a605e986d0f1ffa4b251/railties/lib/rails/application/bootstrap.rb#L46

Cheers,
plu
