### PR TITLE
Added Request#log_device_ignored_lines

### DIFF
--- a/lib/logjam_agent.rb
+++ b/lib/logjam_agent.rb
@@ -124,7 +124,11 @@ module LogjamAgent
   self.max_bytes_all_lines = 1024 * 1024
 
   def self.log_to_log_device?(msg)
-    !(log_device_ignored_lines && msg =~ log_device_ignored_lines)
+    if override_global_ignore_lines?
+      msg !~ request.log_device_ignored_lines
+    else
+      !(log_device_ignored_lines && msg =~ log_device_ignored_lines)
+    end
   rescue
     true
   end
@@ -210,4 +214,9 @@ module LogjamAgent
   def self.forwarder
     @forwarder ||= Forwarders.get(application_name, environment_name)
   end
+
+  def self.override_global_ignore_lines?
+    request && request.log_device_ignored_lines
+  end
+
 end

--- a/lib/logjam_agent/request.rb
+++ b/lib/logjam_agent/request.rb
@@ -7,6 +7,7 @@ end
 module LogjamAgent
   class Request
     attr_reader :fields, :uuid, :start_time
+    attr_accessor :log_device_ignored_lines
 
     def initialize(app, env, initial_fields)
       @app = app


### PR DESCRIPTION
What do you think about that?

In the controller you can tweak the global settings then like that:

```ruby
before_action :override_logjam_ignored_lines

def override_logjam_ignored_lines
  LogjamAgent.request.log_device_ignored_lines = /^\s*(?:Rendered|REDIS)/
end
```
