### PR TITLE
bugfix: make sure remote ip is a string

### DIFF
--- a/lib/logjam_agent/rack/logger.rb
+++ b/lib/logjam_agent/rack/logger.rb
@@ -77,7 +77,7 @@ module LogjamAgent
 
         logjam_request.start_time = start_time
         logjam_fields = logjam_request.fields
-        ip = LogjamAgent.ip_obfuscator(env["action_dispatch.remote_ip"])
+        ip = LogjamAgent.ip_obfuscator(env["action_dispatch.remote_ip"].to_s)
         logjam_fields.merge!(:ip => ip, :host => @hostname)
         logjam_fields.merge!(extract_request_info(request))
 


### PR DESCRIPTION
This fixes the current 0.19.0 release. 

env["action_dispatch.remote_ip"] is not necessary a string,
which seems to be a problem in ```json_encode_payload```.