### PR TITLE
Add ignore_render_events option

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ module LogjamAgent
   # to debug asset request handling.
   self.ignore_asset_requests = Rails.env.development?
 
+  # Disable ActiveSupport::Notifications (and thereby logging) of ActionView
+  # render events. Defaults to false.
+  # self.ignore_render_events = Rails.env.production?
+
   # Configure log level for logging on disk: only lines with a log level
   # greater than or equal to the specified one will be logged to disk.
   # Defaults to Logger::INFO. Note that logjam_agent extends the standard

--- a/lib/logjam_agent.rb
+++ b/lib/logjam_agent.rb
@@ -145,6 +145,9 @@ module LogjamAgent
   mattr_accessor :ignore_asset_requests
   self.ignore_asset_requests = false
 
+  mattr_accessor :ignore_render_events
+  self.ignore_render_events = false
+
   mattr_accessor :log_device_ignored_lines
   self.log_device_ignored_lines = nil
 

--- a/lib/logjam_agent/railtie.rb
+++ b/lib/logjam_agent/railtie.rb
@@ -107,6 +107,12 @@ module LogjamAgent
       EVA
     end
 
+    config.after_initialize do
+      if LogjamAgent.ignore_render_events
+        ActiveSupport::Notifications.unsubscribe("render_template.action_view")
+        ActiveSupport::Notifications.unsubscribe("render_partial.action_view")
+        ActiveSupport::Notifications.unsubscribe("render_collection.action_view")
+      end
+    end
   end
 end
-


### PR DESCRIPTION
@skaes: As discussed, let's provide an option here to unsubscribe from the ActionView render events.
Tested internally with one app. Please merge asap if ok.