### PR TITLE
Allow amqp forwarder to work with bunny version > 1.4.1

### DIFF
--- a/lib/logjam_agent/amqp_forwarder.rb
+++ b/lib/logjam_agent/amqp_forwarder.rb
@@ -88,10 +88,14 @@ module LogjamAgent
       @exchanges[app_env] ||=
         begin
           bunny.start unless bunny.connected?
-          bunny.exchange("request-stream-#{app_env}",
-                         :durable => @config[:exchange_durable],
-                         :auto_delete => @config[:exchange_auto_delete],
-                         :type => :topic)
+          channel = bunny.create_channel
+          Bunny::Exchange.new(
+            channel,
+            :topic,
+            "request-stream-#{app_env}",
+            :durable => @config[:exchange_durable],
+            :auto_delete => @config[:exchange_auto_delete]
+          )
         end
     end
 


### PR DESCRIPTION
Unfortunately logjam_agent doesn't work with bunny version > 1.4.1.  This pull request should fix that. Tested with bunny 1.4.1 and 2.5.1.
