### PR TITLE
split exceptions into two classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ module LogjamAgent
   # higher compression rates.
   # self.compression_method = ZLIB_COMPRESSION
   # self.compression_method = SNAPPY_COMPRESSION
+
+  # Activate the split between hard and soft-exceptions. Soft exceptions are
+  # all exceptions below a log level of Logger::ERROR.
+  # Logjam itself can then display those soft exceptions differently.
+  # defaults to `false`
+  self.split_hard_and_soft_exceptions = true
 end
 ```
 

--- a/lib/logjam_agent.rb
+++ b/lib/logjam_agent.rb
@@ -161,6 +161,9 @@ module LogjamAgent
   mattr_accessor :log_device_log_level
   self.log_device_log_level = Logger::INFO
 
+  mattr_accessor :split_hard_and_soft_exceptions
+  self.split_hard_and_soft_exceptions = false
+
   def self.log_to_log_device?(severity, msg)
     return false if severity < log_device_log_level
     if override_global_ignore_lines?

--- a/lib/logjam_agent/buffered_logger.rb
+++ b/lib/logjam_agent/buffered_logger.rb
@@ -69,7 +69,7 @@ module LogjamAgent
       message ||= block.call || '' if block
       request = LogjamAgent.request
       if message.is_a?(Exception)
-        request.add_exception(message.class.to_s) if request
+        request.add_exception(message.class.to_s, severity) if request
         message = format_exception(message)
       else
         message = message.to_s

--- a/lib/logjam_agent/request.rb
+++ b/lib/logjam_agent/request.rb
@@ -77,10 +77,10 @@ module LogjamAgent
 
     def add_exception(exception, severity = Logger::ERROR)
       @mutex.synchronize do
-        if severity >= Logger::ERROR
-          ((@fields[:exceptions] ||= []) << exception).uniq!
-        else
+        if LogjamAgent.split_hard_and_soft_exceptions && severity < Logger::ERROR
           ((@fields[:soft_exceptions] ||= []) << exception).uniq!
+        else
+          ((@fields[:exceptions] ||= []) << exception).uniq!
         end
       end
     end

--- a/lib/logjam_agent/request.rb
+++ b/lib/logjam_agent/request.rb
@@ -75,9 +75,13 @@ module LogjamAgent
       end
     end
 
-    def add_exception(exception)
+    def add_exception(exception, severity = Logger::ERROR)
       @mutex.synchronize do
-        ((@fields[:exceptions] ||= []) << exception).uniq!
+        if severity >= Logger::ERROR
+          ((@fields[:exceptions] ||= []) << exception).uniq!
+        else
+          ((@fields[:soft_exceptions] ||= []) << exception).uniq!
+        end
       end
     end
 


### PR DESCRIPTION
This is part of the new split between the log-levels of different exceptions. This should probably be merged once logjam-app actually supports the new field. It shouldn't break anything, since it is just a new field (Tolerant Reader approach, hopefully?), but it would hide information if logjam doesn't support it yet.

-------

'Hard' exceptions are still logged in :exceptions, but 'soft' exceptions
are logged in :soft_exceptions. The distinction is based on the severity
of the log-event, with Logger::Error being the threshold. Everything
including and above Logger::Error will be deemed a hard-exception.
Everything else is soft.