### PR TITLE
Fix typo on concat

### DIFF
--- a/lib/logjam_agent/railtie.rb
+++ b/lib/logjam_agent/railtie.rb
@@ -126,7 +126,7 @@ module LogjamAgent
 
             ActiveSupport::Deprecation.silence do
               parts = [ "#{exception.class} (#{exception.message})" ]
-              parts.concact exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
+              parts.concat exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
               parts.concat trace
               logger.fatal parts.join("\n  ")
             end


### PR DESCRIPTION
We found an issue when try to render ActionView::Template errors in development mode. This typo was causing a second exception to be raised, and giving us the generic 500 error page instead of the pretty error page with a back trace.