### PR TITLE
Add STDOUT forwarder

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ module LogjamAgent
                 :rcv_timeo => 5000,
                 :snd_timeo => 5000)
 
+  # Configure JSON logging on STDOUT.
+  # add_forwarder(:stdout)
+
   # Configure ip obfuscation. Defaults to no obfuscation.
   self.obfuscate_ips = true
 

--- a/lib/logjam_agent.rb
+++ b/lib/logjam_agent.rb
@@ -35,6 +35,7 @@ require "logjam_agent/forwarders"
 require "logjam_agent/request"
 require "logjam_agent/buffered_logger"
 require "logjam_agent/syslog_like_formatter"
+require "logjam_agent/stdout_forwarder"
 
 if defined?(Rails) && Rails::VERSION::STRING >= "3.0"
   require "logjam_agent/railtie"
@@ -297,6 +298,7 @@ module LogjamAgent
     case type
     when :zmq then Forwarders.add(ZMQForwarder.new(*args))
     when :amqp then ArgumentError.new("logjam amqp transport no longer supported")
+    when :stdout then Forwarders.add(STDOUTForwarder.new(*args))
     else raise ArgumentError.new("unkown logjam transport: '#{type}'")
     end
   end

--- a/lib/logjam_agent/stdout_forwarder.rb
+++ b/lib/logjam_agent/stdout_forwarder.rb
@@ -1,0 +1,50 @@
+module LogjamAgent
+  class STDOUTForwarder
+    attr_reader :app, :env
+
+    include Util
+
+    def initialize(*args)
+      opts = args.extract_options!
+      @app = args[0] || LogjamAgent.application_name
+      @env = args[1] || LogjamAgent.environment_name
+      @app_env = "#{@app}-#{@env}"
+      @config = opts
+    end
+
+    def reset
+      $stdout.flush
+    end
+
+    def forward(data, options={})
+      app_env = options[:app_env] || @app_env
+      key = options[:routing_key] || "logs.#{app_env.sub('-','.')}"
+      if engine = options[:engine]
+        key += ".#{engine}"
+      end
+      # Bypass compression settings for stdout.
+      msg = LogjamAgent.json_encode_payload(data)
+      $stdout.write("#{msg}\n")
+    rescue => error
+      reraise_expectation_errors!
+      raise ForwardingError.new(error.message)
+    end
+
+    private
+
+    def log_warning(message)
+      LogjamAgent.error_handler.call ForwardingWarning.new(message)
+    end
+
+    if defined?(Mocha)
+      def reraise_expectation_errors! #:nodoc:
+        raise if $!.is_a?(Mocha::ExpectationError)
+      end
+    else
+      def reraise_expectation_errors! #:nodoc:
+        # noop
+      end
+    end
+
+  end
+end

--- a/test/stdout_forwarder_test.rb
+++ b/test/stdout_forwarder_test.rb
@@ -1,0 +1,20 @@
+require_relative "test_helper.rb"
+
+module LogjamAgent
+  class STDOUTForwarderTest < MiniTest::Test
+
+    test "sets up forwarder with empty config" do
+      f = STDOUTForwarder.new
+      assert_equal({}, f.instance_variable_get("@config"))
+    end
+
+    test "encodes the payload without compression" do
+      data = {a: 1, b: "str"}
+      msg = LogjamAgent.json_encode_payload(data)
+      f = STDOUTForwarder.new
+      $stdout.expects(:write).with("#{msg}\n")
+      f.forward(data, :routing_key => "x", :app_env => "a-b")
+    end
+
+  end
+end


### PR DESCRIPTION
First off, thanks for maintaining a gem that supports legacy versions of Rails and Ruby, you're a lifesaver!

The intention of this PR is to add support for printing structured JSON performance logs to standard output. I implemented this as a new `STDOUTForwarder`, but if you'd rather use a simpler implementation, I'm happy to change it.

If you'd rather not maintain this feature at all, feel free to close this PR and I'll just keep pulling from my fork instead. 😄 