### PR TITLE
Don't try to use the error_handler if it's nil

### DIFF
--- a/lib/logjam_agent/zmq_forwarder.rb
+++ b/lib/logjam_agent/zmq_forwarder.rb
@@ -125,7 +125,7 @@ module LogjamAgent
     end
 
     def log_warning(message)
-      LogjamAgent.error_handler.call ForwardingWarning.new(message)
+      LogjamAgent.error_handler&.call ForwardingWarning.new(message)
     end
 
     VALID_RESPONSE_CODES = [200,202]


### PR DESCRIPTION
When setting LogjamAgent.error_handler to nil, any warning would trigger a NoMethodException.
Instead, we simply don't log the warning, which is likely what the person who set the error_handler to nil wanted to achieve.

As per our chat I simply added the safe navigation operator to the offending call.

I did not add a test because it didn't fit with the other zmq_forwarder tests at all. If you want me to add a test, just let me know.