### PR TITLE
Use Rails.application.deprecators.silence for rails >= 7.1

### DIFF
--- a/lib/logjam_agent/railtie.rb
+++ b/lib/logjam_agent/railtie.rb
@@ -140,11 +140,21 @@ module LogjamAgent
             trace = wrapper.application_trace
             trace = wrapper.framework_trace if trace.empty?
 
-            ActiveSupport::Deprecation.silence do
-              parts = [ "#{exception.class} (#{exception.message})" ]
-              parts.concat exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
-              parts.concat trace
-              logger.fatal parts.join("\n  ")
+            if Rails::VERSION::STRING >= "7.1" do
+              Rails.application.deprecators.silence do
+                parts = [ "#{exception.class} (#{exception.message})" ]
+                parts.concat exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
+                parts.concat trace
+                logger.fatal parts.join("\n  ")
+              end
+            else
+              ActiveSupport::Deprecation.silence do
+                parts = [ "#{exception.class} (#{exception.message})" ]
+                parts.concat exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
+                parts.concat trace
+                logger.fatal parts.join("\n  ")
+              end
+  
             end
           end
         end

--- a/lib/logjam_agent/railtie.rb
+++ b/lib/logjam_agent/railtie.rb
@@ -140,7 +140,7 @@ module LogjamAgent
             trace = wrapper.application_trace
             trace = wrapper.framework_trace if trace.empty?
 
-            if Rails::VERSION::STRING >= "7.1" do
+            if Gem::Version.new(Rails::VERSION::STRING) >= Gem::Version.new("7.1.0")
               Rails.application.deprecators.silence do
                 parts = [ "#{exception.class} (#{exception.message})" ]
                 parts.concat exception.annoted_source_code if exception.respond_to?(:annoted_source_code)
@@ -154,7 +154,7 @@ module LogjamAgent
                 parts.concat trace
                 logger.fatal parts.join("\n  ")
               end
-  
+
             end
           end
         end


### PR DESCRIPTION
This fixes https://github.com/skaes/logjam_agent/issues/54 and shows errors again that are just lost atm for apps that already went to rails 7.2.x.

`Rails.application.deprecators` was added with rails 7.1, so have to keep the old way for previous versions
https://github.com/rails/rails/blob/15ddce90583bdf169ae69449b42db10be9f714c9/guides/source/7_1_release_notes.md?plain=1#L18

@skaes could you please check and merge/release a new version?